### PR TITLE
Fix call to get_numeric_channels_values in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ experiment = experiments[0]
 1. get numeric channel values dataframe
     
 ```python
-    channel_df = experiment.get_numeric_channels_values('network_1 epoch_val iou loss')
+    channel_df = experiment.get_numeric_channels_values('network_1', 'epoch_val',  'iou', 'loss')
 ```
     
 2. get hardware utilization dataframe 


### PR DESCRIPTION
experiment.get_numeric_channels_values(...) expects list of channel names. 

Provided example does not work - channel names list should not be embedded in one string.